### PR TITLE
Add Object List Display

### DIFF
--- a/lsd3.lua
+++ b/lsd3.lua
@@ -54,7 +54,7 @@ while true do
 		lank_last_area_x = 0
 	  elseif last_area_x >= -5 then
 		lank_last_area_x = -1
-	  elseif last_area_x >= -9 then
+	  elseif last_area_x <= -6 then
 		lank_last_area_x = -2
 	  end
 	  last_area_y  = memory.readbyte(0x0091675)
@@ -69,7 +69,7 @@ while true do
 		lank_last_area_y = 0
 	  elseif last_area_y >= -5 then
 		lank_last_area_y = -1
-	  elseif last_area_y >= -9 then
+	  elseif last_area_y <= -6 then
 		lank_last_area_y = -2
 	  end
 	  area_counter = memory.readbyte(0x0091680) + memory.readbyte(0x0091681)*256 + memory.readbyte(0x0091682)*256*256 + memory.readbyte(0x0091683)*256*256*256

--- a/lsd3.lua
+++ b/lsd3.lua
@@ -97,7 +97,7 @@ while true do
 		lank_last_chara_x = 0
 	  elseif last_chara_x >= -5 then
 		lank_last_chara_x = -1
-	  elseif last_chara_x >= -9 then
+	  elseif last_chara_x <= -6 then
 		lank_last_chara_x = -2
 	  end
 	  last_chara_y  = memory.readbyte(0x0091685)
@@ -112,7 +112,7 @@ while true do
 		lank_last_chara_y = 0
 	  elseif last_chara_y >= -5 then
 		lank_last_chara_y = -1
-	  elseif last_chara_y >= -9 then
+	  elseif last_chara_y <= -6 then
 		lank_last_chara_y = -2
 	  end
 	  chara_counter = memory.readbyte(0x0091690) + memory.readbyte(0x0091691)*256 + memory.readbyte(0x0091692)*256*256 + memory.readbyte(0x0091693)*256*256*256


### PR DESCRIPTION
This PR adds an object (or "character") list display. Each loaded object is listed, color-coded to indicate its status, and can be configured to show/hide further information.
![image](https://github.com/xen-0sd/LSDebug/assets/12983268/4ef6ceb1-f85b-42d5-a681-43272812f19e)

Objects are displayed in three colors: White, Gray, and Green. An object in gray is loaded but its interactable flag is off, usually meaning its despawned or is waiting to appear. Objects in green have been viewed, approached, or appeared - depending on the object. White is neither. 

The **Object ID** is printed before the name. [They match the listed values here](https://seesaawiki.jp/lsd/d/%a5%ad%a5%e3%a5%e9%a5%b0%a5%e9%a5%d5%a4%ce%b8%c4%c2%ce%c3%cd%a4%de%a4%c8%a4%e1)  (Object 123 is incorrect on that page)

The **Object's state value** is printed after the name. Not every object uses this value, so for most it will always be 0. Some examples of objects using this value:

```
Gunman
0 = (default)
1 = Dead
10 = Turning
11 = Approaching
12 = Falling Over
13 = Shooting

Astronaut
0 = (default)
100 = Landing

Shrine Bell
Number of times the bell has rang (36 times should play the pink petal video)
```

The **Object's X,Y,Z coordinates** are printed after the state value. 

Each of these can be disabled at the top of the script.


### Images
(I didn't change anything to cause the GUI to display like this, it does it by default on my Bizhawk setup)
![image](https://github.com/xen-0sd/LSDebug/assets/12983268/e4a1f1d7-013f-4e7a-99f5-41fb22cb2e7c)
![image](https://github.com/xen-0sd/LSDebug/assets/12983268/9525d791-1b45-4a99-a5e3-cbbb747ed12f)
![image](https://github.com/xen-0sd/LSDebug/assets/12983268/fa4e7423-535b-49e4-9348-b5f7bc0c1dd6)
![image](https://github.com/xen-0sd/LSDebug/assets/12983268/2552a4c9-93e7-441b-a14e-a9b368aab5f7)


